### PR TITLE
fix: resolve npm start typescript execution error with ESM loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "generate:types": "node scripts/generate_types.js",
-    "start": "npm run generate:types && npx ts-node src/logic/agent_brain.ts",
+    "start": "npm run generate:types && NODE_OPTIONS='--import tsx --no-warnings' npx ts-node src/logic/agent_brain.ts",
     "compile": "npx hardhat compile",
     "test": "NODE_OPTIONS='--import tsx --no-warnings' npx hardhat test test/RiskRouter.test.ts && NODE_OPTIONS='--import tsx --no-warnings' npx mocha test/mcp/kraken_mcp.test.ts test/logic/strategy/risk_assessment.test.ts test/utils/checkpoint.test.ts test/onchain/identity.test.ts",
     "demo": "NODE_OPTIONS='--import tsx --no-warnings' npx hardhat run scripts/demo_flow.ts --network hardhat",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
   "ts-node": {
     "esm": true,
     "experimentalEsm": true,
+    "transpileOnly": true,
     "compilerOptions": {
       "module": "ESNext"
     }


### PR DESCRIPTION
Fixes the ERR_UNKNOWN_FILE_EXTENSION error when running `npm start`.

## Changes
- Add `NODE_OPTIONS='--import tsx --no-warnings'` to npm start script for proper TypeScript ESM support in Node v20
- Add `transpileOnly: true` to ts-node config in tsconfig.json for faster transpilation
- Aligns npm start with other scripts (test, demo, hackathon:submit) that already use tsx loader

## Testing
- All tests pass successfully (20+ tests)
- npm start now executes correctly without TypeScript extension errors

## Why
The project uses ES modules (`"type": "module"` in package.json), but the npm start script wasn't using the correct Node.js loader to handle TypeScript in ESM mode. ts-node alone cannot process TypeScript files in pure ESM projects on Node v20 without the tsx import loader.