### PR TITLE
chore: Add npm run register script for agent onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "compile": "npx hardhat compile",
     "test": "NODE_ENV=test NODE_OPTIONS='--import tsx --no-warnings' npx hardhat test test/RiskRouter.test.ts && NODE_ENV=test NODE_OPTIONS='--import tsx --no-warnings' npx mocha test/**/*.test.ts --exclude test/RiskRouter.test.ts",
     "demo": "NODE_OPTIONS='--import tsx --no-warnings' npx hardhat run scripts/demo_flow.ts --network hardhat",
+    "register": "NODE_OPTIONS='--import tsx --no-warnings' npx hardhat run scripts/deploy_sepolia.ts --network sepolia",
     "onboard:sepolia": "NODE_OPTIONS='--import tsx --no-warnings' npx hardhat run scripts/deploy_sepolia.ts --network sepolia",
     "hackathon:submit": "NETWORK=sepolia KRAKEN_CLI_PATH=/home/asif1/hackathons/VertexAgents-The-Sentinel-Layer/scripts/mock_kraken.sh NODE_OPTIONS='--import tsx --no-warnings' npx hardhat run scripts/hackathon_submit.ts --network sepolia",
     "node": "npx hardhat node",


### PR DESCRIPTION
## Summary

Adds a convenience script to register agent on Sepolia.

## Usage

```bash
npm run register
```

This fixes the TypeScript execution error when running `npx hardhat run scripts/deploy_sepolia.ts --network sepolia` directly.

## What it does

1. Registers your agent in the shared AgentRegistry on Sepolia
2. Claims 0.05 ETH sandbox capital from HackathonVault
3. Creates `deployments_sepolia.json` with your agentId

## Prerequisites

`.env` must have:
- `AGENT_PRIVATE_KEY` - Your agent wallet private key
- `INFURA_KEY` - For Sepolia RPC

Your operator wallet needs Sepolia ETH for gas.

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._