### PR TITLE
chore: update .env.example and .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,14 @@
 # Copy this file to .env and fill in your values.
 # NEVER commit the real .env file.
 
-# Agent private key (for local demo ONLY — use a throwaway key, never a funded wallet)
-AGENT_PRIVATE_KEY=0x...your_throwaway_private_key_here
+# Agent private key (for EIP-712 signing and on-chain interactions)
+AGENT_PRIVATE_KEY=0x...your_agent_private_key_here
+
+# General private key (fallback for scripts/deployment)
+PRIVATE_KEY=0x...your_general_private_key_here
+
+# Network (e.g., sepolia, mainnet)
+NETWORK=sepolia
 
 # Strykr PRISM API key (canonical asset resolution)
 STRYKR_PRISM_API=prism_sk_...your_api_key_here
@@ -14,3 +20,8 @@ INFURA_KEY=...your_infura_key_here
 # Google AI API key (for Genkit risk scoring flows)
 # The googleai plugin expects GOOGLE_GENAI_API_KEY
 GOOGLE_GENAI_API_KEY=...your_google_ai_key_here
+
+# Kraken API Credentials (for live trading execution)
+KRAKEN_API_KEY=...your_kraken_api_key_here
+KRAKEN_SECRET=...your_kraken_secret_here
+

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,7 @@ deployments_sepolia.json
 # ── OS ───────────────────────────────────────────────────────
 .DS_Store
 Thumbs.db
-.external_template/
+
+# ── Logs ─────────────────────────────────────────────────────
+logs/
+*.log


### PR DESCRIPTION
This PR updates .env.example with missing keys from .env and includes the recent .gitignore updates (ignoring logs).