### PR TITLE
Update agent name to match leaderboard

### DIFF
--- a/agent-id.json
+++ b/agent-id.json
@@ -1,5 +1,5 @@
 {
-  "name": "Vertex Sentinel Alpha",
+  "name": "Vertex Sentinel Layer",
   "version": "1.0.0",
   "agentId": 1
 }

--- a/docs/DASHBOARD_DESIGN_RECS.md
+++ b/docs/DASHBOARD_DESIGN_RECS.md
@@ -10,7 +10,7 @@
 Based on our repository analysis and analysis of existing templates, the dashboard should adopt a **"Modular Card-and-Grid"** layout to improve information density without cluttering the UI.
 
 ### A. Global Monitoring Header (The "Control Bar")
-- **Agent Identity & Version:** Clearly display the Agent Name (e.g., "Vertex Sentinel Alpha") and version from `agent-id.json`.
+- **Agent Identity & Version:** Clearly display the Agent Name (e.g., "Vertex Sentinel Layer") and version from `agent-id.json`.
 - **System Heartbeat:** A pulsing indicator (e.g., Emerald for Online, Crimson for Offline) connected to the Kraken MCP and RiskRouter health.
 - **Fail-Closed Status Badge:** A "Glassmorphism" badge stating "🛡️ FAIL-CLOSED ACTIVE" to confirm safety guardrails.
 - **Global Actions:**


### PR DESCRIPTION
Fixing the mismatch between local agent-id.json ('Vertex Sentinel Alpha') and the official leaderboard name ('Vertex Sentinel Layer').